### PR TITLE
Convert search results to ranked list view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,34 @@ main { padding: 20px; }
 .card img { width: 100%; height: 140px; object-fit: contain; background: #0f1430; border-radius: 8px; }
 .card .meta { display:flex; justify-content: space-between; align-items: center; color: var(--muted); }
 
+.results-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
+.list-item {
+  background: var(--card);
+  border: 1px solid #222a46;
+  border-radius: 12px;
+  padding: 12px 16px;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+.list-item:hover { border-color: #3a4b7a; transform: translateY(-2px); }
+.list-thumb {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  background: #0f1430;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+.list-body { flex: 1; display: flex; justify-content: space-between; align-items: center; gap: 16px; }
+.list-text { display: flex; flex-direction: column; gap: 4px; }
+.list-name { font-size: 1.1rem; font-weight: 600; }
+.list-id { color: var(--muted); font-variant-numeric: tabular-nums; }
+.list-meta { color: var(--muted); font-size: 0.875rem; }
+
 .search-input {
   width: 100%;
   padding: 10px 12px;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -28,26 +28,50 @@ export default function SearchPage() {
     })();
   }, []);
 
+  const getRelevanceScore = React.useCallback((pokemon: PokemonListItem, q: string) => {
+    const name = pokemon.name.toLowerCase();
+    const idMatch = String(pokemon.id) === q;
+    if (idMatch) return 0;
+    if (name === q) return 1;
+    if (name.startsWith(q)) return 2;
+    if (name.includes(q)) return 3;
+    return 4;
+  }, []);
+
   const filtered = React.useMemo(() => {
     const q = query.trim().toLowerCase();
-    let out = items.filter((p) =>
-      q ? p.name.includes(q) || String(p.id) === q : true
-    );
 
-    out.sort((a, b) => {
+    const decorated = items
+      .filter((p) => (q ? p.name.includes(q) || String(p.id) === q : true))
+      .map((pokemon) => ({
+        pokemon,
+        relevance: q
+          ? getRelevanceScore(pokemon, q)
+          : 0,
+      }));
+
+    decorated.sort((a, b) => {
+      if (a.relevance !== b.relevance) {
+        return a.relevance - b.relevance;
+      }
+
       let comp = 0;
-      if (sortKey === "name") comp = a.name.localeCompare(b.name);
-      else comp = a.id - b.id;
+      if (sortKey === "name") {
+        comp = a.pokemon.name.localeCompare(b.pokemon.name);
+      } else {
+        comp = a.pokemon.id - b.pokemon.id;
+      }
+
       return order === "asc" ? comp : -comp;
     });
 
-    return out;
-  }, [items, query, sortKey, order]);
+    return decorated.map((entry) => entry.pokemon);
+  }, [items, query, sortKey, order, getRelevanceScore]);
 
   return (
     <div className="page">
       <h1>Pokémon Search</h1>
-      <p>Filter as you type. Click a card for details.</p>
+      <p>Filter as you type. Results are sorted from most to least relevant.</p>
       <div className="stack-12">
         <SearchBar value={query} onChange={setQuery} placeholder="Name or exact ID" />
         <SortControls sortKey={sortKey} order={order} onSortKey={setSortKey} onOrder={setOrder} />
@@ -56,17 +80,30 @@ export default function SearchPage() {
       {loading && <p>Loading…</p>}
       {error && <p role="alert">{error}</p>}
 
-      <div className="grid">
+      {!loading && !error && filtered.length === 0 && (
+        <p role="status">No Pokémon match your search.</p>
+      )}
+
+      <ul className="results-list" role="list">
         {filtered.map((p) => (
-          <Link key={p.id} to={`/pokemon/${p.id}`} className="card" aria-label={`View ${p.name}`}>
-            <img src={p.image} alt={p.name} />
-            <div className="meta">
-              <strong>#{p.id}</strong>
-              <span className="cap">{p.name}</span>
-            </div>
-          </Link>
+          <li key={p.id}>
+            <Link
+              to={`/pokemon/${p.id}`}
+              className="list-item"
+              aria-label={`View details for ${p.name}`}
+            >
+              <img src={p.image} alt={p.name} className="list-thumb" loading="lazy" />
+              <div className="list-body">
+                <div className="list-text">
+                  <span className="list-name cap">{p.name}</span>
+                  <span className="list-id">#{p.id}</span>
+                </div>
+                <span className="list-meta">View details</span>
+              </div>
+            </Link>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- convert the Pokémon search page to a vertical list view that ranks matches by relevance while respecting sort controls
- add list-specific styling and empty-state messaging for the filtered results

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5be531e80832ea3539a6967d61f95